### PR TITLE
Just attempt to open the cache file rather than testing for it first.

### DIFF
--- a/lib/maxfield.py
+++ b/lib/maxfield.py
@@ -498,15 +498,17 @@ def loadCache(a, ab):
     bestgraph = None
     bestplan = None
     bestdist = np.inf
-    if os.path.isfile(cachefile):
+    try:
         global _dist_matrix
-        logger.info('Loading cache data from cache %s', cachefile)
         wc = shelve.open(cachefile, 'r')
+        logger.info('Loading cache data from cache %s', cachefile)
         _dist_matrix = wc['dist_matrix']
         bestgraph = wc['bestgraph']
         bestplan = wc['bestplan']
         bestdist = wc['bestdist']
         wc.close()
+    except:
+        pass
     return (bestgraph, bestplan, bestdist)
 
 


### PR DESCRIPTION
The underlying db filename may have a suffix added (like `.db`)

Instead of checking for a specific filename, just attempt to access the cache (inside a `try` block).