### PR TITLE
Fix issue with duplicate sheet names in Google Sheets output

### DIFF
--- a/lib/gsheets.py
+++ b/lib/gsheets.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import datetime
 
 from googleapiclient.discovery import build
 from httplib2 import Http
@@ -282,6 +283,22 @@ def write_workplan(service, spid, a, workplan, stats, faction, travelmode='walki
     dtitle = '%s %s (%0.2fkm/%dP/%sAP)' % (travelmoji[travelmode], stats['nicetime'], totalkm,
                                            a.order()-n_waypoints, '{:,}'.format(stats['ap']))
     logger.info('Adding "%s" sheet with %d actions', dtitle, len(workplan))
+    
+     # Check if a sheet with the same name already exists
+    sheet_exists = False
+    sheets = service.spreadsheets().get(spreadsheetId=spid, fields='sheets(properties(title))').execute().get('sheets', [])
+    for sheet in sheets:
+        if sheet['properties']['title'] == dtitle:
+            sheet_exists = True
+            break
+
+    # Append a timestamp to the sheet name if it already exists
+    if sheet_exists:
+        timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+        dtitle += ' ' + timestamp
+        logger.info('Sheet "%s" already exists, using "%s" instead', dtitle, dtitle)
+        
+        
     requests.append({
         'addSheet': {
             'properties': {


### PR DESCRIPTION
This commit addresses an issue where the script would crash if a new solution had the same name as a previous one, since the Google Sheets API does not allow multiple sheets with the same name. To resolve this, the code now checks if a sheet with the same name already exists in the spreadsheet, and if so, appends a unique identifier (a timestamp) to the sheet name before creating it. This ensures that each sheet has a unique name and prevents the script from crashing.

Changes include:

* Modifying the `write_workplan` function in `gsheets.py` to check if a sheet with the same name already exists in the spreadsheet.
* Appending a unique identifier (a timestamp) to the sheet name if a sheet with the same name already exists.
* Updating the logger messages to reflect the new behavior.

This change should improve the reliability of the script and prevent crashes due to duplicate sheet names.